### PR TITLE
Utilize player input

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -52,4 +52,23 @@ class Board
       puts
     end
   end
+
+  def change_slots(input)
+    open_slot_index = find_open_slot(input)
+    place_chip(input, open_slot_index)
+    draw_board
+  end
+
+  def find_open_slot(input)
+    @slots[input].find_index do |slot|
+      "."
+    end  #=> 0 (#class = integer)
+  end
+
+  def place_chip(input, open_slot_index)
+    @slots[input][open_slot_index] = "X"
+  end
+
+
+
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -53,7 +53,7 @@ class Board
     end
   end
 
-  def change_slots(input)
+  def fill_slot(input)
     open_slot_index = find_open_slot(input)
     place_chip(input, open_slot_index)
     draw_board

--- a/lib/connect_four.rb
+++ b/lib/connect_four.rb
@@ -6,7 +6,7 @@ board = Board.new
 puts "Which slot would you like to select? Enter A,B,C,D,E,F, or G. >"
 input = gets.chomp.upcase
 
-board.change_slots(input)
+board.fill_slot(input)
 # if guess_input == "A"
 # if guess_input == "B"
 # take user input, check that column -> find.first slot with "."

--- a/lib/connect_four.rb
+++ b/lib/connect_four.rb
@@ -4,11 +4,12 @@ puts "Welcome! Let's play Connect Four!"
 board = Board.new
 
 puts "Which slot would you like to select? Enter A,B,C,D,E,F, or G. >"
-guess_input = gets.chomp.upcase
+input = gets.chomp.upcase
 
+board.change_slots(input)
 # if guess_input == "A"
 # if guess_input == "B"
 # take user input, check that column -> find.first slot with "."
   # -> change slot to "X"
 # implement the computer's turn
-  # pick random column letter -> same loop 
+  # pick random column letter -> same loop

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -10,4 +10,16 @@ class BoardTest < Minitest::Test
     assert_instance_of Board, board
   end
 
+  def test_it_finds_open_slot
+    board = Board.new
+    input = "A"
+    assert_equal 0, board.find_open_slot(input)
+  end
+
+  def test_it_places_chip_in_open_slot
+    board = Board.new
+    input = "A"
+    open_slot_index = board.find_open_slot(input)
+    assert_equal "X", board.place_chip(input, open_slot_index)
+  end
 end


### PR DESCRIPTION
This adds the ability for player input to be used. This takes user input, checks the corresponding column for the first open slot (first slot with "."), and changes that slot to "X". It also prints the updated board to terminal. However, it currently fills the top slot on the board, rather than the bottom slot as it should. The next goal will be to fix this. It may be that when the board is printed to terminal, it is printed upside-down. 

