### PR TITLE
change method for drawing slots to print board right-side-up

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -39,16 +39,15 @@ class Board
     slots.each do |letter, slot|
       print letter
     end
-    puts
   end
 
   def draw_slots
-    count = 0
-    until count == 7
+    count = 7
+    until count < 0
       slots.each do |letter, slot|
-          print slot[count]
+        print slot[count]
       end
-      count += 1
+      count -= 1
       puts
     end
   end


### PR DESCRIPTION
This changes the method for drawing slots to print the board right-side-up. It changes the order it prints in by counting down from index 7 (subtracting 1 each time from 7 to 0) instead of counting up to index 7 (adding 1 each time from 0 to 7).